### PR TITLE
fix(ng-chartist): get nativeElement from ElementRef in ngOnInit()

### DIFF
--- a/projects/ng-chartist/src/lib/chartist.component.ts
+++ b/projects/ng-chartist/src/lib/chartist.component.ts
@@ -62,11 +62,7 @@ export class ChartistComponent implements OnInit, OnChanges, OnDestroy {
   // @ts-ignore
   public chart: ChartInterfaces;
 
-  private element: HTMLElement;
-
-  constructor(element: ElementRef) {
-    this.element = element.nativeElement;
-  }
+  constructor(private elementRef: ElementRef) {}
 
   public ngOnInit(): Promise<ChartInterfaces> {
     if (!this.type || !this.data) {
@@ -95,7 +91,7 @@ export class ChartistComponent implements OnInit, OnChanges, OnDestroy {
   public renderChart(): Promise<ChartInterfaces> {
     const promises: any[] = [
       this.type,
-      this.element,
+      this.elementRef.nativeElement,
       this.data,
       this.options,
       this.responsiveOptions


### PR DESCRIPTION
In some cases nativeElement is not set during class initialization, so we should assign it ngOnInit() method instead of constructor.