### PR TITLE
fix(style): load Chartist stylesheet before demo app stylesheet

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -56,8 +56,8 @@
               "projects/ng-chartist-demo/src/assets"
             ],
             "styles": [
-              "projects/ng-chartist-demo/src/styles.css",
-              "node_modules/chartist/dist/chartist.css"
+              "node_modules/chartist/dist/chartist.css",
+              "projects/ng-chartist-demo/src/styles.css"
             ],
             "scripts": []
           },
@@ -113,8 +113,8 @@
             "tsConfig": "projects/ng-chartist-demo/tsconfig.spec.json",
             "karmaConfig": "projects/ng-chartist-demo/karma.conf.js",
             "styles": [
-              "projects/ng-chartist-demo/src/styles.css",
-              "node_modules/chartist/dist/chartist.css"
+              "node_modules/chartist/dist/chartist.css",
+              "projects/ng-chartist-demo/src/styles.css"
             ],
             "scripts": [],
             "assets": [

--- a/projects/ng-chartist-demo/src/styles.css
+++ b/projects/ng-chartist-demo/src/styles.css
@@ -5,5 +5,5 @@ x-chartist {
 }
 
 .ct-label {
-    font-size: 1.25rem !important;
+    font-size: 1.25rem;
 }


### PR DESCRIPTION
Load Chartist stylesheet before demo app stylesheet and remove "!important" CSS rule.