### PR TITLE
"initialized" event emitted when the chart object is created

### DIFF
--- a/projects/ng-chartist/src/lib/chartist.component.spec.ts
+++ b/projects/ng-chartist/src/lib/chartist.component.spec.ts
@@ -47,7 +47,20 @@ describe('chartist component', () => {
 
     instance.ngOnInit();
 
-    expect(instance.chart instanceof Chartist.Bar).toBe(true);
+    expect(instance['chart'] instanceof Chartist.Bar).toBe(true);
+  });
+
+  it('should emit initialized event when chart is initialized', () => {
+    const chartType: ChartType = 'Bar';
+
+    instance.data = data[chartType];
+    instance.type = chartType;
+
+    spyOn(<any>instance.initialized, 'emit').and.callThrough();
+
+    instance.ngOnInit();
+
+    expect(instance.initialized.emit).toHaveBeenCalled();
   });
 
   it('should bind events if there are events', () => {
@@ -81,13 +94,28 @@ describe('chartist component', () => {
     expect(instance['renderChart']).toHaveBeenCalled();
   });
 
+  it('should emit initialized event when the chart type changes', () => {
+    spyOn(<any>instance.initialized, 'emit').and.callThrough();
+
+    instance.type = 'Bar';
+    instance.data = data.Bar;
+
+    instance.ngOnChanges({
+      type: <any>{
+        currentValue: instance.type
+      }
+    });
+
+    expect(instance.initialized.emit).toHaveBeenCalled();
+  });
+
   it('should update the chart if the data changes', () => {
     instance.data = data.Bar;
     instance.type = 'Bar';
 
     instance.ngOnInit();
 
-    spyOn(instance.chart, 'update').and.callThrough();
+    spyOn(instance['chart'], 'update').and.callThrough();
     spyOn(<any>instance, 'renderChart').and.callThrough();
 
     instance.ngOnChanges({
@@ -97,7 +125,7 @@ describe('chartist component', () => {
     });
 
     expect(instance['renderChart']).not.toHaveBeenCalled();
-    expect(instance.chart.update).toHaveBeenCalled();
+    expect(instance['chart'].update).toHaveBeenCalled();
   });
 
   it('should update the chart if the options change', () => {
@@ -106,7 +134,7 @@ describe('chartist component', () => {
 
     instance.ngOnInit();
 
-    spyOn(instance.chart, 'update').and.callThrough();
+    spyOn(instance['chart'], 'update').and.callThrough();
     spyOn(<any>instance, 'renderChart').and.callThrough();
 
     instance.options = {
@@ -119,7 +147,7 @@ describe('chartist component', () => {
     });
 
     expect(instance['renderChart']).not.toHaveBeenCalled();
-    expect(instance.chart.update).toHaveBeenCalled();
+    expect(instance['chart'].update).toHaveBeenCalled();
   });
 
   it('should not initialize chart when type is missing', () => {
@@ -127,7 +155,7 @@ describe('chartist component', () => {
 
     instance.ngOnInit();
 
-    expect(instance.chart).toBeUndefined();
+    expect(instance['chart']).toBeUndefined();
   });
 
   it('should not initialize chart when data is missing', () => {
@@ -135,6 +163,6 @@ describe('chartist component', () => {
 
     instance.ngOnInit();
 
-    expect(instance.chart).toBeUndefined();
+    expect(instance['chart']).toBeUndefined();
   });
 });

--- a/projects/ng-chartist/src/lib/chartist.component.ts
+++ b/projects/ng-chartist/src/lib/chartist.component.ts
@@ -1,10 +1,12 @@
 import {
   Component,
   ElementRef,
+  EventEmitter,
   Input,
   OnChanges,
   OnDestroy,
   OnInit,
+  Output,
   SimpleChanges
 } from '@angular/core';
 
@@ -89,7 +91,7 @@ export class ChartistComponent implements OnInit, OnChanges, OnDestroy {
   responsiveOptions: ResponsiveOptions;
 
   /**
-   * Events object where keys are event names and values are event handler functions.
+   * Events object where keys are Chartist event names and values are event handler functions.
    *
    * Supported events are: draw, optionsChanged, data, animationBegin, animationEnd, created.
    *
@@ -99,9 +101,15 @@ export class ChartistComponent implements OnInit, OnChanges, OnDestroy {
   events: ChartEvent;
 
   /**
-   * Chartist chart instance
+   * Event emitted after Chartist chart has been initialized.
+   *
+   * Event handler function will receive chart instance argument.
    */
-  public chart: ChartInterfaces;
+  @Output()
+  initialized = new EventEmitter<ChartInterfaces>();
+
+  /** @ignore */
+  private chart: ChartInterfaces;
 
   /** @ignore */
   constructor(private elementRef: ElementRef) {}
@@ -144,6 +152,8 @@ export class ChartistComponent implements OnInit, OnChanges, OnDestroy {
     if (this.events) {
       this.bindEvents();
     }
+
+    this.initialized.emit(this.chart);
   }
 
   /** @ignore */


### PR DESCRIPTION
Introduced "initialized" event which can be used to get Chartist chart instance once the chart has been initialized without relying on "chart" class property which can be undefined and should be private.