### PR TITLE
Remove greenkeeper from CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,5 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-        # https://github.com/greenkeeperio/greenkeeper-lockfile#setup
-      - run: npx greenkeeper-lockfile-update
-
       # run tests!
       - run: yarn test
-
-      - run: npx greenkeeper-lockfile-upload

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![npm version](https://badge.fury.io/js/ng-chartist.svg)](http://badge.fury.io/js/ng-chartist)
 [![NPM downloads](https://img.shields.io/npm/dt/ng-chartist.svg)](https://npmjs.org/package/ng-chartist)
-[![CircleCI](https://circleci.com/gh/willsoto/ng-chartist.svg?style=shield)](https://circleci.com/gh/willsoto/ng-chartist) [![Greenkeeper badge](https://badges.greenkeeper.io/willsoto/ng-chartist.svg)](https://greenkeeper.io/)
+[![CircleCI](https://circleci.com/gh/willsoto/ng-chartist.svg?style=shield)](https://circleci.com/gh/willsoto/ng-chartist)
+[![Greenkeeper badge](https://badges.greenkeeper.io/willsoto/ng-chartist.svg)](https://greenkeeper.io/)
 
 ## Demo
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "codelyzer": "~4.5.0",
     "copyfiles": "^2.1.0",
     "core-js": "^2.6.2",
-    "greenkeeper-lockfile": "^2.8.0",
     "husky": "^1.3.1",
     "jasmine-core": "~3.3.0",
     "jasmine-spec-reporter": "~4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3362,7 +3362,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-glob@^2.0.2, fast-glob@^2.2.0:
+fast-glob@^2.0.2:
   version "2.2.6"
   resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.6.tgz#a5d5b697ec8deda468d85a74035290a025a95295"
   integrity sha512-0BvMaZc1k9F+MeWWMe8pL6YltFzZYcJsYU7D4JyDA6PAczaXvxqQQ/z+mDF7/4Mw01DeUc+i3CTKajnkANkV4w==
@@ -3985,22 +3985,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   version "4.1.15"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-greenkeeper-lockfile@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.npmjs.org/greenkeeper-lockfile/-/greenkeeper-lockfile-2.8.0.tgz#7100d046a1dac8f1d87f5448b2d361b593d05a85"
-  integrity sha512-/oHC503XQOWm77DbXVc7NqRBzqgc8XkDKnDoD16BIC2KZ82zGn8qdquuoyDE2paf1bgz31xqgsu6gFro309ruA==
-  dependencies:
-    fast-glob "^2.2.0"
-    greenkeeper-monorepo-definitions "^1.0.0"
-    lodash "^4.17.10"
-    require-relative "^0.8.7"
-    semver "^5.3.0"
-
-greenkeeper-monorepo-definitions@^1.0.0:
-  version "1.12.0"
-  resolved "https://registry.npmjs.org/greenkeeper-monorepo-definitions/-/greenkeeper-monorepo-definitions-1.12.0.tgz#bef47c8d2392c0d22ba771783b9efc4158330acb"
-  integrity sha512-3sZ0EsXQDOv8K0QnSTK9GKjIiS4AZLQUe75uSSd2i0RTsInEi/sZBV8yQmGv3ZS4CZGLUJ6OK90Hk3qln/QGTA==
 
 handle-thing@^2.0.0:
   version "2.0.0"
@@ -7672,11 +7656,6 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
-
-require-relative@^0.8.7:
-  version "0.8.7"
-  resolved "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
-  integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Since greenkeeper now has native support for lockfiles, there is no need to run "greenkeeper-lockfile-update" and "greenkeeper-lockfile-upload".
See [Announcing Native Lockfile Support](https://blog.greenkeeper.io/announcing-native-lockfile-support-85381a37a0d0) blog post for more info.